### PR TITLE
Fixes error regarding `imghdr` no longer being available

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.25.1
 simplejson>=3.17.2
+filetype

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ python_requires = >=3.6
 install_requires=
     requests>=2.25.1
     simplejson>=3.17.2
+    filetype
 
 [options.packages.find]
 where = src

--- a/src/deathbycaptcha/__init__.py
+++ b/src/deathbycaptcha/__init__.py
@@ -70,7 +70,7 @@ Visit http://www.deathbycaptcha.com/user/api for updates.
 
 import base64
 import errno
-import imghdr
+import filetype
 import random
 import select
 import socket
@@ -129,7 +129,7 @@ def _load_image(captcha):
             captcha_file.close()
     if not len(img):
         raise ValueError('CAPTCHA image is empty')
-    elif imghdr.what(None, img) is None:
+    elif filetype.guess(img) is None:
         raise TypeError('Unknown CAPTCHA image type')
     else:
         return img

--- a/src/deathbycaptcha/deathbycaptcha.py
+++ b/src/deathbycaptcha/deathbycaptcha.py
@@ -70,7 +70,7 @@ Visit http://www.deathbycaptcha.com/user/api for updates.
 
 import base64
 import errno
-import imghdr
+import filetype
 import random
 import select
 import socket
@@ -129,7 +129,7 @@ def _load_image(captcha):
             captcha_file.close()
     if not len(img):
         raise ValueError('CAPTCHA image is empty')
-    elif imghdr.what(None, img) is None:
+    elif filetype.guess(img) is None:
         raise TypeError('Unknown CAPTCHA image type')
     else:
         return img


### PR DESCRIPTION
[`imghdr` was removed in Python 3.13](https://docs.python.org/3/whatsnew/3.13.html#whatsnew313-pep594). Attempting to install the DBC Python library on 3.13 generates an error.

This PR fixes that error by switching to using the `filetype` library for determining the type of an image instead.